### PR TITLE
Fix `datetime` reference to pydantic model

### DIFF
--- a/pyst_client/models/association_input.py
+++ b/pyst_client/models/association_input.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
-from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List

--- a/pyst_client/models/concept.py
+++ b/pyst_client/models/concept.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
-from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/pyst_client/models/concept_scheme_input.py
+++ b/pyst_client/models/concept_scheme_input.py
@@ -16,11 +16,11 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
-from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from typing_extensions import Annotated
+from pyst_client.models.date_time import DateTime
 from pyst_client.models.multilingual_string import MultilingualString
 from pyst_client.models.node import Node
 from pyst_client.models.non_literal_note import NonLiteralNote
@@ -42,7 +42,7 @@ class ConceptSchemeInput(BaseModel):
     http___www_w3_org_2004_02_skos_corechange_note: Optional[List[NonLiteralNote]] = Field(default=None, alias="http://www.w3.org/2004/02/skos/core#changeNote")
     http___www_w3_org_2004_02_skos_corehistory_note: Optional[List[NonLiteralNote]] = Field(default=None, alias="http://www.w3.org/2004/02/skos/core#historyNote")
     http___www_w3_org_2004_02_skos_coreeditorial_note: Optional[List[NonLiteralNote]] = Field(default=None, alias="http://www.w3.org/2004/02/skos/core#editorialNote")
-    http___purl_org_dc_terms_created: Annotated[List[datetime], Field(min_length=1, max_length=1)] = Field(description="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/created", alias="http://purl.org/dc/terms/created")
+    http___purl_org_dc_terms_created: Annotated[List[DateTime], Field(min_length=1, max_length=1)] = Field(description="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/created", alias="http://purl.org/dc/terms/created")
     http___purl_org_dc_terms_creator: List[Node] = Field(description="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/creator", alias="http://purl.org/dc/terms/creator")
     http___www_w3_org_2002_07_owlversion_info: Annotated[List[VersionString], Field(min_length=1, max_length=1)] = Field(description="https://www.w3.org/TR/owl-ref/#versionInfo-def", alias="http://www.w3.org/2002/07/owl#versionInfo")
     http___www_w3_org_2004_02_skos_coredefinition: Annotated[List[MultilingualString], Field(min_length=1)] = Field(description="https://www.w3.org/TR/skos-primer/#secdocumentation", alias="http://www.w3.org/2004/02/skos/core#definition")
@@ -189,5 +189,3 @@ class ConceptSchemeInput(BaseModel):
                 _obj.additional_properties[_key] = obj.get(_key)
 
         return _obj
-
-

--- a/pyst_client/models/concept_scheme_output.py
+++ b/pyst_client/models/concept_scheme_output.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
-from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/pyst_client/models/correspondence_input.py
+++ b/pyst_client/models/correspondence_input.py
@@ -16,11 +16,11 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
-from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from typing_extensions import Annotated
+from pyst_client.models.date_time import DateTime
 from pyst_client.models.multilingual_string import MultilingualString
 from pyst_client.models.node import Node
 from pyst_client.models.non_literal_note import NonLiteralNote
@@ -42,7 +42,7 @@ class CorrespondenceInput(BaseModel):
     http___www_w3_org_2004_02_skos_corechange_note: Optional[List[NonLiteralNote]] = Field(default=None, alias="http://www.w3.org/2004/02/skos/core#changeNote")
     http___www_w3_org_2004_02_skos_corehistory_note: Optional[List[NonLiteralNote]] = Field(default=None, alias="http://www.w3.org/2004/02/skos/core#historyNote")
     http___www_w3_org_2004_02_skos_coreeditorial_note: Optional[List[NonLiteralNote]] = Field(default=None, alias="http://www.w3.org/2004/02/skos/core#editorialNote")
-    http___purl_org_dc_terms_created: Annotated[List[datetime], Field(min_length=1, max_length=1)] = Field(description="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/created", alias="http://purl.org/dc/terms/created")
+    http___purl_org_dc_terms_created: Annotated[List[DateTime], Field(min_length=1, max_length=1)] = Field(description="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/created", alias="http://purl.org/dc/terms/created")
     http___purl_org_dc_terms_creator: List[Node] = Field(description="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/creator", alias="http://purl.org/dc/terms/creator")
     http___www_w3_org_2002_07_owlversion_info: Annotated[List[VersionString], Field(min_length=1, max_length=1)] = Field(description="https://www.w3.org/TR/owl-ref/#versionInfo-def", alias="http://www.w3.org/2002/07/owl#versionInfo")
     http___www_w3_org_2004_02_skos_coredefinition: Optional[List[MultilingualString]] = Field(default=None, description="https://www.w3.org/TR/skos-primer/#secdocumentation", alias="http://www.w3.org/2004/02/skos/core#definition")

--- a/pyst_client/models/correspondence_output.py
+++ b/pyst_client/models/correspondence_output.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
-from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional


### PR DESCRIPTION
The actual expected `datetime` object is `DateTime` as defined in pydantic model for the API.
The generator probably got confused given similarity in the name.
This made it impossible to use this client library to create `ConceptSchemeInput` and `CorrespondenceInput` as it would produce an HTTP 422 on the API.