### PR TITLE
fix: update license descriptors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,12 @@ maintainers = [
 description = "A Python client library for the PyST (Python Semantic Taxonomy) API"
 readme = "README.md"
 dynamic = ["version"]
-license = {file = "LICENSE"}
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.12"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
Before this commit, building the package yielded errors regarding the definition of license and license-files.

Signed-off by: Tomás NAVARRETE

🧅 too